### PR TITLE
fix: `RuntimeError: dictionary changed size` when yielding class attributes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Removed
 
 Fixed
 =====
+- Made a shallow copy of ``__dict__`` when iterating over class attributes to fix potential ``RuntimeError``
 
 Security
 

--- a/pyof/foundation/base.py
+++ b/pyof/foundation/base.py
@@ -586,7 +586,7 @@ class GenericStruct(metaclass=MetaStruct):
         """
         #: see this method docstring for a important notice about the use of
         #: cls.__dict__
-        for name, value in cls.__dict__.items():
+        for name, value in cls.__dict__.copy().items():
             # gets only our (pyof) attributes. this ignores methods, dunder
             # methods and attributes, and common python type attributes.
             if GenericStruct._is_pyof_attribute(value):
@@ -605,7 +605,7 @@ class GenericStruct(metaclass=MetaStruct):
             generator: tuples with attribute name and value.
 
         """
-        for name, value in self.__dict__.items():
+        for name, value in self.__dict__.copy().items():
             if name in map((lambda x: x[0]), self.get_class_attributes()):
                 yield (name, value)
 


### PR DESCRIPTION
Closes #84 
Clsoes https://github.com/kytos-ng/of_core/issues/112

### Summary

See updated changelog file

### Local Tests

- Reran `kytosd` locally with this `pyof` branch, provisiond an EVC and also tried to reinject the same event, no issues were observed:

```
2023-05-23 16:48:08,437 - INFO [uvicorn.access] (MainThread) 127.0.0.1:44368 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2023-05-23 16:48:08,443 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_14) Failover path for EVC(a123e0a649604b, epl) was deployed.

kytos $> from kytos.core.events import KytosEvent                                                                                                                                       

kytos $>     conn = controller.switches['00:00:00:00:00:00:00:01'].connection 
    ...:     content = { 
    ...:         "source": conn, 
    ...:         "new_data": b"\x04\x13\x01\x18\xc7\r\xd5\xf5\x00\x01\x00\x00\x00\x00\x00\x00\x00X\x00\x00\x00\x00\x00\n.\x8d\x1d@\xc3P\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\xac\x00\
    ...: x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x0e\x80\x00\x08\x06\xee\xee\xee\xee\xee\x03\x00\x00\x00\x04\x00\x18\x00\x00
    ...: \x00\x00\x00\x00\x00\x10\xff\xff\xff\xfd\xff\xff\x00\x00\x00\x00\x00\x00\x00X\x00\x00\x00\x00\x00\n.n\x98\xc0\xc3P\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\xac\x00\x00\x00\x00\
    ...: x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x0e\x80\x00\x08\x06\xee\xee\xee\xee\xee\x02\x00\x00\x00\x04\x00\x18\x00\x00\x00\x00\x00
    ...: \x00\x00\x10\xff\xff\xff\xfd\xff\xff\x00\x00\x00\x00\x00\x00\x00X\x00\x00\x00\x00\x00\x0b\x19\xdeP\x80\x03\xe8\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\xab\x00\x00\x00\x00\x00\
    ...: x00\x01\x00\x00\x00\x00\x00\x00\x00\x08\x00\x00\x00\x00\x00\x00\x01P\x00\x01\x00\x10\x80\x00\n\x02\x88\xcc\x80\x00\x0c\x02\x1e\xd7\x00\x04\x00\x18\x00\x00\x00\x00\x00\x00\x00\
    ...: x10\xff\xff\xff\xfd\xff\xff\x00\x00\x00\x00\x00\x00", 
    ...:     } 
    ...:     event = KytosEvent("kytos/core.openflow.raw.in", content) 
    ...:     controller.buffers.app.put(event)                                                                                                                                          

kytos $>                                                                                                                                                                                

```

### End-to-End Tests

In-progress. I've dispatched an e2e execution, I'll update with the results here later.
