### PR TITLE
Create the ListOfTableId and use it on NextTableProperty

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Fixed
 =====
 - Added missing ``ActionPopMPLS.length`` attribute to fix ``PackException`` when packing objects.
 - Correct return value for ``get_size()`` when used with ``ActionHeader`` objects directly (useful for TableFeatures Properties).
+- Fix ``NextTableProperty.next_table_ids`` to correctly export only the Table IDs
 
 [2025.1.0] - 2025-04-14
 ***********************

--- a/pyof/v0x04/controller2switch/common.py
+++ b/pyof/v0x04/controller2switch/common.py
@@ -22,7 +22,7 @@ __all__ = ('ConfigFlag', 'ControllerRole', 'TableFeaturePropType',
            'MultipartType', 'Bucket', 'BucketCounter', 'ListOfBucketCounter',
            'ExperimenterMultipartHeader', 'Property', 'InstructionsProperty',
            'NextTablesProperty', 'ActionsProperty', 'OxmProperty',
-           'ListOfProperty', 'TableFeatures')
+           'ListOfTableId', 'ListOfProperty', 'TableFeatures')
 
 # Enum
 
@@ -509,6 +509,25 @@ class InstructionsProperty(Property):
         self.update_length()
 
 
+class ListOfTableId(FixedTypeList):
+    """List of Table IDs.
+
+    Represented by instances of UBInt8.
+    """
+
+    def __init__(self, items=None):
+        """Create a ListOfTableId with the optional parameters below.
+
+        Args:
+            items (|UBInt8|): Instance or a list of instances.
+
+        """
+        items = [
+            x if isinstance(x, UBInt8) else UBInt8(x) for x in items or []
+        ]
+        super().__init__(pyof_class=UBInt8, items=items)
+
+
 class NextTablesProperty(Property):
     """Next Tables Property.
 
@@ -517,7 +536,7 @@ class NextTablesProperty(Property):
         OFPTFPT_NEXT_TABLES_MISS
     """
 
-    next_table_ids = ListOfInstruction()
+    next_table_ids = ListOfTableId()
 
     def __init__(self, property_type=TableFeaturePropType.OFPTFPT_NEXT_TABLES,
                  next_table_ids=None):
@@ -526,13 +545,16 @@ class NextTablesProperty(Property):
         Args:
             type(|TableFeaturePropType_v0x04|):
                 Property Type value of this instance.
-            next_table_ids (|ListOfInstruction_v0x04|):
-                List of InstructionGotoTable instances.
+            next_table_ids (|ListOfTableId_v0x04|):
+                List of UBInt8 (Table IDs) instances.
 
         """
         super().__init__(property_type)
-        self.next_table_ids = (ListOfInstruction() if next_table_ids is None
-                               else next_table_ids)
+        self.next_table_ids = (
+            next_table_ids
+            if isinstance(next_table_ids, ListOfTableId)
+            else ListOfTableId(next_table_ids)
+        )
         self.update_length()
 
 


### PR DESCRIPTION
Closes #101

### Summary

See updated changelog file and/or add any other summarized helpful information for reviewers

### Local Tests

Without the changes proposed here (i.e., using ListOfInstruction with InstructionGotoTable [as suggested in the code](https://github.com/kytos-ng/python-openflow/blob/be80da79dd12dda608db1fc94fe3149300fccd45/pyof/v0x04/controller2switch/common.py#L529-L530)):
```
> python3
Python 3.13.2 (main, Feb  4 2025, 14:51:09) [Clang 16.0.0 (clang-1600.0.26.6)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from pyof.v0x04.common.flow_instructions import ListOfInstruction, InstructionGotoTable
>>> from pyof.v0x04.controller2switch.common import NextTablesProperty, TableFeaturePropType
>>> loi = ListOfInstruction([InstructionGotoTable(table_id=1), InstructionGotoTable(table_id=2), InstructionGotoTable(table_id=3)])
>>> next_tb_prop = NextTablesProperty(property_type=TableFeaturePropType.OFPTFPT_NEXT_TABLES, next_table_ids=loi)
>>> next_tb_prop.pack()
b'\x00\x02\x00\x1c\x00\x01\x00\x08\x01\x00\x00\x00\x00\x01\x00\x08\x02\x00\x00\x00\x00\x01\x00\x08\x03\x00\x00\x00'
>>> len(next_tb_prop.pack())
28
>>>
```

As you can see above, the length of the NextTablesProperty became much bigger than expected (28 bytes, while it was expected to be 7 bytes). We can also check a packet capture from Noviflow Switch:

<img width="734" height="631" alt="Screenshot 2025-11-21 at 17 34 58" src="https://github.com/user-attachments/assets/a2fa34c6-b9c5-4a4f-b74b-fd5ce39307e6" />

Now, after fixing this issue:

```
> python3
Python 3.13.2 (main, Feb  4 2025, 14:51:09) [Clang 16.0.0 (clang-1600.0.26.6)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from pyof.v0x04.controller2switch.common import NextTablesProperty, TableFeaturePropType
>>> next_tb_prop = NextTablesProperty(property_type=TableFeaturePropType.OFPTFPT_NEXT_TABLES, next_table_ids=[1,2,3])
>>> next_tb_prop.pack()
b'\x00\x02\x00\x07\x01\x02\x03'
>>> len(next_tb_prop.pack())
7
```

Packing and unpacking works as expected:
```
>>> from pyof.v0x04.controller2switch.common import NextTablesProperty, TableFeaturePropType
>>> packed = NextTablesProperty(property_type=TableFeaturePropType.OFPTFPT_NEXT_TABLES, next_table_ids=[1,2,3])
>>> unpacked = NextTablesProperty().unpack(packed.pack())
>>> unpacked = NextTablesProperty()
>>> unpacked.unpack(packed.pack())
>>> packed == unpacked
True
>>>
```

### End-to-End Tests

Please refer to the results presented here: https://github.com/kytos-ng/python-openflow/pull/110

The end-to-end tests were executed with all PRs stacked